### PR TITLE
Add weirdness pair records for biome configs

### DIFF
--- a/Common/src/main/java/corgitaco/corgilib/serialization/codec/CodecUtil.java
+++ b/Common/src/main/java/corgitaco/corgilib/serialization/codec/CodecUtil.java
@@ -147,4 +147,15 @@ public class CodecUtil {
 
     public record WrapForSerialization<T>(T value) {
     }
+
+    public record WeirdnessPair<T>(T normal, T variant) {
+        public static <T> Codec<WeirdnessPair<T>> codec(Codec<T> baseCodec) {
+            return RecordCodecBuilder.create(
+                    builder -> builder.group(
+                            baseCodec.fieldOf("normal").forGetter(pair -> pair.normal),
+                            baseCodec.fieldOf("variant").forGetter(pair -> pair.variant)
+                    ).apply(builder, WeirdnessPair::new)
+            );
+        }
+    }
 }


### PR DESCRIPTION
This is a small addition for a change in the overworld region configs.
For example change:
```json
"middle_biomes": "middle_biomes/middle_biomes_1.json",
"middle_biomes_variant": "middle_biomes_variant/middle_biomes_variant_1.json"
```
into:
```json
"middle_biomes": {
    "normal": "middle_biomes/middle_biomes_1.json",
    "variant": "middle_biomes_variant/middle_biomes_variant_1.json"
}
```
This is in order to simplify the config and mitigate an issue where codecs cannot handle constructors with more than 16 parameters.